### PR TITLE
feat(hardhat-resolc): Enable batch compilation

### DIFF
--- a/packages/hardhat-resolc/src/compile/binary.ts
+++ b/packages/hardhat-resolc/src/compile/binary.ts
@@ -1,37 +1,75 @@
 import { exec } from 'child_process';
-import { ResolcConfig } from '../types';
+import { ContractBatch, ContractSource, ResolcConfig } from '../types';
 import { CompilerInput } from 'hardhat/types';
-import { extractCommands } from '../utils';
+import { extractCommands, mapImports, orderSources } from '../utils';
 
 export async function compileWithBinary(
     input: CompilerInput,
     config: ResolcConfig,
 ): Promise<any> {
     const {
-        compilerPath
+        compilerPath,
+        batchSize
     } = config.settings;
 
     const commands = extractCommands(config);
 
     let processCommand = `${compilerPath} ${commands.join(' ')}`;
 
-    const output: string = await new Promise((resolve, reject) => {
-        const process = exec(
-            processCommand,
-            {
-                maxBuffer: 1024 * 1024 * 500,
-            },
-            (err, stdout, _stderr) => {
-                if (err !== null) {
-                    return reject(err);
-                }
-                resolve(stdout);
-            },
-        );
+    const map = mapImports(input);
 
-        process.stdin!.write(JSON.stringify(input));
-        process.stdin!.end();
-    });
+    const ordered = orderSources(map)
 
-    return JSON.parse(output);
+    if (batchSize) {
+        let selectedContracts: ContractBatch = {};
+        for (let i = 0; i * batchSize < ordered.length; i++) {
+            selectedContracts = ordered.reduce((acc, key) => {
+                acc[key] = input.sources[key];
+                return acc;
+            }, {} as ContractSource);
+
+            const contractBatch: ContractBatch = { "language": input.language, "sources": selectedContracts, "settings": input.settings };
+
+            const output: string = await new Promise((resolve, reject) => {
+                const process = exec(
+                    processCommand,
+                    {
+                        maxBuffer: 1024 * 1024 * 500,
+                    },
+                    (err, stdout, _stderr) => {
+                        if (err !== null) {
+                            return reject(err);
+                        }
+                        resolve(stdout);
+                    },
+                );
+
+                process.stdin!.write(JSON.stringify(contractBatch));
+                process.stdin!.end();
+            });
+
+            return JSON.parse(output)
+        };
+
+    } else {
+        const output: string = await new Promise((resolve, reject) => {
+            const process = exec(
+                processCommand,
+                {
+                    maxBuffer: 1024 * 1024 * 500,
+                },
+                (err, stdout, _stderr) => {
+                    if (err !== null) {
+                        return reject(err);
+                    }
+                    resolve(stdout);
+                },
+            );
+
+            process.stdin!.write(JSON.stringify(input));
+            process.stdin!.end();
+        });
+
+        return JSON.parse(output);
+    }
 }

--- a/packages/hardhat-resolc/src/compile/index.ts
+++ b/packages/hardhat-resolc/src/compile/index.ts
@@ -3,6 +3,7 @@ import { ResolcConfig } from "../types";
 import { compileWithBinary } from "./binary";
 import { compileWithRemix } from "./remix";
 import { ResolcPluginError } from "../errors";
+import chalk from 'chalk';
 
 export interface ICompiler {
     compile(input: CompilerInput, config: ResolcConfig): Promise<any>;
@@ -17,6 +18,8 @@ export async function compile(resolcConfig: ResolcConfig, input: CompilerInput) 
         }
         compiler = new BinaryCompiler(resolcConfig);
     } else if (resolcConfig.compilerSource === 'remix') {
+        if (resolcConfig.settings.batchSize) console.warn(chalk.yellow('Batch compilation is only available for `binary` source.\nSetting batchSize will be ignored.'));
+        
         compiler = new RemixCompiler(resolcConfig);
     } else {
         throw new ResolcPluginError(`Incorrect compiler source: ${resolcConfig.compilerSource}`);

--- a/packages/hardhat-resolc/src/types.ts
+++ b/packages/hardhat-resolc/src/types.ts
@@ -73,6 +73,8 @@ export interface ResolcConfig {
         disableSolcOptimizer?: boolean;
         // Try to recompile with -Oz if the bytecode is too large.
         fallbackToOptimizingForSize?: boolean;
+        // Compile in batches. Useful for environmnents with limited resources and large number of files.
+        batchSize?: number;
     };
 }
 
@@ -136,4 +138,12 @@ export interface SolcInput {
 export interface SolcConfigData {
     compiler: SolcConfig;
     file?: string;
+}
+
+export interface ContractBatch {
+    [key: string]: object | string;
+}
+
+export interface ContractSource {
+    [key: string]: object;
 }

--- a/packages/hardhat-resolc/src/types.ts
+++ b/packages/hardhat-resolc/src/types.ts
@@ -147,3 +147,19 @@ export interface ContractBatch {
 export interface ContractSource {
     [key: string]: object;
 }
+
+export interface Sources {
+    [key: string]: {
+        id: number,
+        ast: object
+    }
+}
+
+export interface CompiledOutput {
+    contracts: ContractSource,
+    sources: Sources,
+    errors: string[],
+    version: string,
+    long_version: string,
+    revive_version: string,
+}

--- a/packages/hardhat-resolc/src/utils.ts
+++ b/packages/hardhat-resolc/src/utils.ts
@@ -1,6 +1,6 @@
 import { Artifact, CompilerInput } from "hardhat/types";
 import { ARTIFACT_FORMAT_VERSION } from "hardhat/internal/constants";
-import { ResolcConfig, SolcConfigData } from "./types";
+import { CompiledOutput, ResolcConfig, SolcConfigData } from "./types";
 import { COMPILER_RESOLC_NEED_EVM_CODEGEN } from "./constants";
 import chalk from 'chalk';
 import { ResolcPluginError } from "./errors";
@@ -448,4 +448,20 @@ export function orderSources(mapped: Map<string, string[]>): string[] {
   })
 
   return ordered
+}
+
+export function deepUpdate(a: CompiledOutput, b: CompiledOutput): CompiledOutput {
+  const keys = Object.keys(b.sources);
+  const lastId = Object.keys(a.sources).length - 1;
+  let nextIds = lastId + Object.keys(b.sources).length;
+  if (Object.keys(a.sources).length === 0) {
+      return b
+  } else {
+      keys.forEach((key) => {
+          a.contracts = Object.assign({}, a.contracts, { [key]: b.contracts[key] });
+          a.sources = Object.assign({}, a.sources, { [key]: { id: nextIds, ast: b.sources[key].ast } })
+          nextIds++
+      })
+  }
+  return a;
 }

--- a/packages/hardhat-resolc/src/utils.ts
+++ b/packages/hardhat-resolc/src/utils.ts
@@ -1,4 +1,4 @@
-import { Artifact } from "hardhat/types";
+import { Artifact, CompilerInput } from "hardhat/types";
 import { ARTIFACT_FORMAT_VERSION } from "hardhat/internal/constants";
 import { ResolcConfig, SolcConfigData } from "./types";
 import { COMPILER_RESOLC_NEED_EVM_CODEGEN } from "./constants";
@@ -405,4 +405,47 @@ export function extractCommands(config: ResolcConfig): string[] {
     return extractRemainingCommands(config, commandArgs);
   
   };
+}
+
+export function extractImports(fileContent: string): string[] {
+  const importRegex =
+      /import\s+(?:"([^"]+)"|'([^']+)'|(?:[^'"]+)\s+from\s+(?:"([^"]+)"|'([^']+)'))\s*;/g;
+  let imports: string[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = importRegex.exec(fileContent)) !== null) {
+      const importedPath = match[1] || match[2] || match[3] || match[4];
+      if (importedPath) {
+          imports.push(importedPath);
+      }
+  }
+  return imports;
+}
+
+export function mapImports(input: CompilerInput): Map<string, string[]> {
+  const keys = Object.keys(input.sources);
+  const map = new Map<string, string[]>();
+  for (let key of keys) {
+      const importArray = extractImports(input.sources[key].content);
+      map.set(key, importArray)
+  }
+  return map;
+}
+
+export function orderSources(mapped: Map<string, string[]>): string[] {
+  let ordered: string[] = [];
+
+  mapped.forEach((values, key) => {
+      for (let value of values) {
+          if (ordered.includes(value)) continue;
+
+          ordered.push(value);
+      }
+
+      if (ordered.includes(key)) return;
+
+      ordered.push(key)
+  })
+
+  return ordered
 }


### PR DESCRIPTION
### Description
This adds a config option for the binary compiler to compile the files in batches, useful for compilation in environments with limited resources and projects with a large number of contracts to compile.