### PR TITLE
fix(bug): Updated types

### DIFF
--- a/packages/hardhat-resolc/README.md
+++ b/packages/hardhat-resolc/README.md
@@ -14,11 +14,17 @@ time it allows for selecting either `remix` as the compilation backend or the
 `resolc` binary, with full support for their respective optional commands.
 
 ### Requirements
+In order to use the plugin, it must be imported at the top of the `hardhat.config`
+file, in order to override the relevant `hardhat` tasks.
+
 When using the `resolc` binary, it's required to state the path to the binary and
 fullfiling all other requirements as described by the [installation section](https://github.com/paritytech/revive?tab=readme-ov-file#installation)
 of the `pallet revive` repo. If you need to compile to a solidity version different
 from the `solc` you have installed, the corresponding version's binary must be
 present and the path specified in the configuration.
+
+**NOTE**
+Usage of absolute paths are recommended.
 
 When using the `remix` backend for compilation, the solidity version of the project
 must be >= 0.8.0, since the backend is hardcoded for that compiler version.

--- a/packages/hardhat-resolc/src/type-extensions.ts
+++ b/packages/hardhat-resolc/src/type-extensions.ts
@@ -16,24 +16,24 @@ declare module 'hardhat/types/config' {
     }
 
     interface HttpNetworkUserConfig {
-        polkavm: HttpNetworkConfig
+        polkavm?: HttpNetworkConfig
     }
 
     interface HardhatNetworkConfig {
-        polkavm: boolean;
+        polkavm?: boolean;
     }
 
     interface HttpNetworkConfig {
-        polkavm: boolean;
+        polkavm?: boolean;
     }
 
     interface NetworksConfig {
-        polkavm: HttpNetworkConfig
+        polkavm?: HttpNetworkConfig
     }
 }
 
 declare module 'hardhat/types/runtime' {
     interface Network {
-        polkavm: boolean;
+        polkavm?: boolean;
     }
 }

--- a/packages/hardhat-revive-node/README.md
+++ b/packages/hardhat-revive-node/README.md
@@ -8,6 +8,9 @@ chain using `@acala-network/chopsticks` and use the Polkadot-SDK `eth-rpc-adapte
 to enable local testing.
 
 ### Requirements
+In order to use the plugin, it must be imported at the top of the `hardhat.config`
+file, in order to override the relevant `hardhat` tasks.
+
 Both when connecting to a live chain endpoint and when forking one, it is required that the
 path to the `eth-rpc-adapter` binary is specified, unless the endpoint you are
 connecting to is Ethereum compatible, otherwise all the calls will fail.
@@ -17,8 +20,6 @@ of the chain you are connecting to, else you will receive the following error:
 ```bash
 Metadata error: The generated code is not compatible with the node
 ```
-As of 14/01/2025, that version can be built from the Polkadot-SDK's [`stable2412`
-branch](https://github.com/paritytech/polkadot-sdk/tree/stable2412).
 
 ### Configuration of standalone node
 We can run the node locally as either a fork of a live chain or using local binaries.
@@ -49,6 +50,9 @@ type to see the available configuration options.
 | --build-block-mode                  | Build block mode for chopsticks.                                                                                     |
 | --fork                              | Endpoint of the chain to fork.                                                                                       |
 | --fork-block-number                 | Block hash or block number from where to fork.                                                                       |
+
+**NOTE**
+Usage of absolute paths are recommended.
 
 ### Configuration for testing
 When used for testing you have two options, either provide the configuration inside

--- a/packages/hardhat-revive-node/src/type-extensions.ts
+++ b/packages/hardhat-revive-node/src/type-extensions.ts
@@ -13,18 +13,18 @@ declare module 'hardhat/types/config' {
     }
 
     interface HardhatNetworkConfig {
-        polkavm: boolean;
-        url: string;
+        polkavm?: boolean;
+        url?: string;
     }
 
     interface HttpNetworkConfig {
-        polkavm: boolean;
+        polkavm?: boolean;
         ethNetwork?: string;
     }
 }
 
 declare module 'hardhat/types/runtime' {
     interface Network {
-        polkavm: boolean;
+        polkavm?: boolean;
     }
 }


### PR DESCRIPTION
### Description
Updated `type-extensions` to make some values optional, to avoid forcing the user to define "polkavm" and allow it to be undefined.